### PR TITLE
fixes for breaking ui in specific ranges for the sponser section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "load-script": "^2.0.0",
         "lucide-react": "^0.379.0",
         "moment": "^2.30.1",
+        "motion": "^11.13.1",
         "nanoid": "^5.0.7",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
@@ -5878,16 +5879,19 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "11.2.10",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.2.10.tgz",
-      "integrity": "sha512-/gr3PLZUVFCc86a9MqCUboVrALscrdluzTb3yew+2/qKBU8CX6nzs918/SRBRCqaPbx0TZP10CB6yFgK2C5cYQ==",
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.15.0.tgz",
+      "integrity": "sha512-MLk8IvZntxOMg7lDBLw2qgTHHv664bYoYmnFTmE0Gm/FW67aOJk0WM3ctMcG+Xhcv+vh5uyyXwxvxhSeJzSe+w==",
+      "license": "MIT",
       "dependencies": {
+        "motion-dom": "^11.14.3",
+        "motion-utils": "^11.14.3",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
         "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/is-prop-valid": {
@@ -9440,6 +9444,44 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/motion": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-11.15.0.tgz",
+      "integrity": "sha512-iZ7dwADQJWGsqsSkBhNHdI2LyYWU+hA1Nhy357wCLZq1yHxGImgt3l7Yv0HT/WOskcYDq9nxdedyl4zUv7UFFw==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^11.15.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.14.3",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.14.3.tgz",
+      "integrity": "sha512-lW+D2wBy5vxLJi6aCP0xyxTxlTfiu+b+zcpVbGVFUxotwThqhdpPRSmX8xztAgtZMPMeU0WGVn/k1w4I+TbPqA==",
+      "license": "MIT"
+    },
+    "node_modules/motion-utils": {
+      "version": "11.14.3",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.14.3.tgz",
+      "integrity": "sha512-Xg+8xnqIJTpr0L/cidfTTBFkvRw26ZtGGuIhA94J9PQ2p4mEa06Xx7QVYZH0BP+EpMSaDlu+q0I0mmvwADPsaQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.2",

--- a/src/sections/Home/Sponser/styles/Sponser.module.scss
+++ b/src/sections/Home/Sponser/styles/Sponser.module.scss
@@ -191,11 +191,11 @@
 @media (min-width: 481px) and (max-width: 730px) {
   .sponser_div {
     height: 24rem;
-    width: 35rem;
+    width: 30rem;
   }
 
   .sponser_all {
-    width: 35rem;
+    width: 30rem;
     margin-top: 3rem;
   }
 
@@ -226,7 +226,7 @@
 
   .sponser_div {
     height: 22rem;
-    width: 50rem;
+    width: 48rem;
   }
 
   .sponser_all {

--- a/src/sections/Home/Sponser/styles/Sponser.module.scss
+++ b/src/sections/Home/Sponser/styles/Sponser.module.scss
@@ -221,7 +221,9 @@
 
 
 
-@media (min-width: 750px) and (max-width: 900px) {
+@media (min-width: 769px) and (max-width: 890px) {
+
+
   .sponser_div {
     height: 22rem;
     width: 50rem;
@@ -238,6 +240,7 @@
   }
 
   .sponser_title {
+    padding-top: 24%;
     font-size: 48px;
     margin-top: -12rem;
   }

--- a/src/sections/Home/Sponser/styles/Sponser.module.scss
+++ b/src/sections/Home/Sponser/styles/Sponser.module.scss
@@ -1,4 +1,4 @@
-.sponser_container {
+.sponser_container { 
   width: 100%;
   height: auto;
   display: flex;
@@ -185,5 +185,69 @@
   .sponser_container{
     width: 93%;
     margin-left: 0.8rem;
+  }
+}
+
+@media (min-width: 481px) and (max-width: 730px) {
+  .sponser_div {
+    height: 24rem;
+    width: 35rem;
+  }
+
+  .sponser_all {
+    width: 35rem;
+    margin-top: 3rem;
+  }
+
+  .sponser_card {
+    height: 4.5rem;
+    width: 4.5rem;
+  }
+
+  .sponser_title {
+    font-size: 35px;
+    margin-top: -15rem;
+  }
+
+  .bottom_line {
+    width: 6rem;
+    margin-left: 10rem;
+  }
+
+  .sponser_container {
+    padding-top: 2rem;
+  }
+}
+
+
+
+@media (min-width: 750px) and (max-width: 900px) {
+  .sponser_div {
+    height: 22rem;
+    width: 50rem;
+  }
+
+  .sponser_all {
+    width: 50rem;
+    margin-top: 4rem;
+  }
+
+  .sponser_card {
+    height: 5.5rem;
+    width: 5.5rem;
+  }
+
+  .sponser_title {
+    font-size: 48px;
+    margin-top: -12rem;
+  }
+
+  .bottom_line {
+    width: 10rem;
+    margin-left: 12rem;
+  }
+
+  .sponser_container {
+    padding-top: 2.5rem;
   }
 }


### PR DESCRIPTION
## Description

The Sponsor section layout breaks between 481px to 730px and 769px to 890px screen widths.
[<!-- Please provide a brief description of your changes and explain the purpose of the PR. -->](https://github.com/fed-tech/FED-Frontend/issues/225)

## Changes Made

2 new css for specific ranges to save ui from breaking

481px to 730px

![image](https://github.com/user-attachments/assets/498d96a0-7334-48ed-9b9e-a08e6eb70640)

769px to 890px 

![image](https://github.com/user-attachments/assets/2e460b7c-23b0-459e-9874-5324e4192ad2)


## Types of Changes

What type of changes does your code introduce? (Check all that apply)

- [*] Bug fix (non-breaking change which fixes an issue) 🐛
- [ ] New feature (non-breaking change which adds functionality) ✨
- [ ] UI enhancement (non-breaking change which enhances UI) 🎨
- [ ] Documentation update 📚

- Fixes #

## Screenshots (if applicable)

<!-- If your changes include any UI updates, add screenshots here to show the changes. -->

